### PR TITLE
Test-reviewdog-origin

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -16,6 +16,9 @@ RUN dnf -y makecache && \
 # Install reviewdog using Go (since no Fedora package available)
 RUN GOBIN=/usr/local/bin go install github.com/reviewdog/reviewdog/cmd/reviewdog@v0.20.3
 
+# TEST: Add package without version pinning to trigger hadolint DL3008
+RUN dnf install -y wget
+
 # Install kind binary
 RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64 && \
     chmod +x ./kind && \

--- a/Containerfile
+++ b/Containerfile
@@ -33,6 +33,9 @@ COPY LICENSE /licenses/
 
 RUN microdnf install -y "squid-${SQUID_VERSION}" && microdnf clean all
 
+# TEST: Add package without cleanup to trigger hadolint DL3009
+RUN microdnf install -y curl
+
 COPY --chmod=0755 container-entrypoint.sh /usr/sbin/container-entrypoint.sh
 
 # move location of pid file to a directory where squid user can recreate it


### PR DESCRIPTION
- Add curl install without cleanup in main Containerfile
- Add wget install without version pinning in devcontainer Containerfile
- These should trigger DL3040 and DL3041 hadolint warnings
- Will be reverted after testing reviewdog comments

Signed-off-by: Barak Korren <bkorren@redhat.com>
Assisted-by: Claude-3.5-Sonnet (via Cursor)